### PR TITLE
Improve build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 node_modules
 .cache
-public

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
-node_modules
-.cache
+# ignore everything
+**
+
+# allow required directories
+!deployment/docker
+!public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,8 @@
-FROM scmmanager/node-build:12.16.3 as builder
-
-ARG GITHUB_API_TOKEN
-ARG SITE_URL
-ENV LOG_LEVEL=debug
-ENV GITHUB_API_TOKEN=$GITHUB_API_TOKEN
-ENV SITE_URL=$SITE_URL
-
-# compile application
-WORKDIR /src/app
-COPY package.json yarn.lock ./
-RUN yarn install
-COPY . .
-RUN yarn build
-
-FROM nginx:1.17.9
+FROM nginx:1.19.2
 
 COPY deployment/docker/redirects.conf /etc/nginx/redirects.conf
 COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
-COPY --from=builder /src/app/public /usr/share/nginx/html
+COPY public /usr/share/nginx/html
 
 RUN chown -R nginx:nginx /var/cache/nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:1.19.2
 
+# if more files are required, ensure .dockerignore does not exclude them
 COPY deployment/docker/redirects.conf /etc/nginx/redirects.conf
 COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
 COPY public /usr/share/nginx/html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,12 +76,11 @@ node('docker') {
         build job: 'scm-manager-github/plugin-center-api/master', wait: false
       }
 
-    }
+      stage('Update Cache') {
+        sh "tar cfz website.tar.gz public .cache"
+        googleStorageUpload bucket: 'gs://scm-manager/cache', credentialsId: 'ces-operations-internal', pattern: 'website.tar.gz'
+      }
 
-    // TODO we should only update the cache on master builds
-    stage('Update Cache') {
-      sh "tar cfz website.tar.gz public .cache"
-      googleStorageUpload bucket: 'gs://scm-manager/cache', credentialsId: 'ces-operations-internal', pattern: 'website.tar.gz'
     }
 
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,12 @@ node('docker') {
 
     }
 
+    // TODO only on master branch
+    stage('Update Cache') {
+      sh "tar cfz website.tar.gz public .cache"
+      googleStorageUpload bucket: 'gs://scm-manager/cache', credentialsId: 'ces-operations-internal', pattern: 'website.tar.gz'
+    }
+
   }
 
   void withNode(Closure closure) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node('docker') {
     stage('Build') {
       withCredentials([usernamePassword(credentialsId: 'cesmarvin-github', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_ACCOUNT')]) {
         def siteUrl = env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
-        withEnv(["SITE_URL=${siteUrl}"]) {
+        withEnv(["SITE_URL=${siteUrl}", "HOME=${env.WORKSPACE}"]) {
           docker.image('scmmanager/node-build:12.16.3').inside {
             sh "yarn install"
             sh "yarn build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,20 +79,20 @@ node('docker') {
 
   }
 
-  void withNode(Closure closure) {
-    docker.image('scmmanager/node-build:12.16.3').inside {
-      withEnv(["HOME=${env.WORKSPACE}"]) {
-        closure.call()
-      }
+}
+
+void withNode(Closure closure) {
+  docker.image('scmmanager/node-build:12.16.3').inside {
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+      closure.call()
     }
   }
+}
 
-  void withHelm(Closure closure) {
-    docker.image('lachlanevenson/k8s-helm:v3.2.1', '--entrypoint=""').inside {
-      withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
-        closure.call()
-      }
+void withHelm(Closure closure) {
+  docker.image('lachlanevenson/k8s-helm:v3.2.1', '--entrypoint=""').inside {
+    withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
+      closure.call()
     }
   }
-
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,91 +1,70 @@
-#!/usr/bin/env groovy
-def version = 'UNKNOWN'
+#!groovy
+node('docker') {
 
-pipeline {
+  def version = 'UNKNOWN'
 
- options {
-   buildDiscarder(logRotator(numToKeepStr: '10'))
-   disableConcurrentBuilds()
- }
+  properties([
+    // Keep only the last 10 build to preserve space
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    disableConcurrentBuilds()
+  ])
 
-  agent {
-    node {
-      label 'docker'
+  timeout(activity: true, time: 30, unit: 'MINUTES') {
+
+    stage('Checkout') {
+      checkout scm
     }
-  }
-
-  stages {
 
     stage('Environment') {
-      steps {
-        script {
-          def commitHashShort = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
-          version = "${new Date().format('yyyyMMddHHmm')}-${commitHashShort}".trim()
-        }
-      }
+      // TODO staging and prod use the same image and version scheme?
+      def commitHashShort = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
+      version = "${new Date().format('yyyyMMddHHmm')}-${commitHashShort}".trim()
     }
 
-    stage('Docker') {
-      agent {
-        node {
-          label 'docker'
-        }
-      }
-      steps {
-        script {
-          withCredentials([usernamePassword(credentialsId: 'cesmarvin-github', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_ACCOUNT')]) {
-            docker.withRegistry('', 'hub.docker.com-cesmarvin') {
-              def siteUrl = env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
-              def image = docker.build("scmmanager/website:${version}", "--build-arg GITHUB_API_TOKEN=${GITHUB_API_TOKEN} --build-arg SITE_URL=${siteUrl} .")
-              image.push()
-            }
+    stage('Build') {
+      withCredentials([usernamePassword(credentialsId: 'cesmarvin-github', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_ACCOUNT')]) {
+        def siteUrl = env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
+        withEnv(["SITE_URL=${siteUrl}"]) {
+          docker.image('scmmanager/node-build:12.16.3').inside {
+            sh "yarn install"
+            sh "yarn build"
           }
         }
       }
     }
 
-    stage('Deployment Staging') {
-      when {
-        branch 'staging'
-      }
-      agent {
-        docker {
-          image 'lachlanevenson/k8s-helm:v3.2.1'
-          args  '--entrypoint=""'
-        }
-      }
-      steps {
-        withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
-          sh "helm upgrade --install --values=deployment/staging.yml --set image.tag=${version} staging-website deployment/website"
-        }
+    stage('Image') {
+      def image = docker.build "scmmanager/website:${version}"
+      docker.withRegistry('', 'hub.docker.com-cesmarvin') {
+        image.push()
       }
     }
 
-    stage('Deployment Production') {
-      when {
-        branch 'master'
-      }
-      agent {
-        docker {
-          image 'lachlanevenson/k8s-helm:v3.2.1'
-          args  '--entrypoint=""'
-        }
-      }
-      steps {
-        withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
-          sh "helm upgrade --install --set image.tag=${version} website deployment/website"
-        }
-      }
-    }
+    if (env.BRANCH_NAME == 'staging') {
 
-    stage('Trigger API Build') {
-      when {
-        branch 'master'
+      stage('Staging Deployment') {
+        docker.image('lachlanevenson/k8s-helm:v3.2.1', '--entrypoint=""').inside {
+          withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
+            sh "helm upgrade --install --values=deployment/staging.yml --set image.tag=${version} staging-website deployment/website"
+          }
+        }
       }
-      steps {
+
+    } else if (env.BRANCH_NAME == 'master') {
+
+      stage('Deployment') {
+        docker.image('lachlanevenson/k8s-helm:v3.2.1', '--entrypoint=""').inside {
+          withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
+            sh "helm upgrade --install --set image.tag=${version} website deployment/website"
+          }
+        }
+      }
+
+      stage('Trigger API Build') {
         build job: 'scm-manager-github/plugin-center-api/master', wait: false
       }
+
     }
-    
+
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ node('docker') {
       def siteUrl = env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
       withNode {
         withEnv(["SITE_URL=${siteUrl}"]) {
-          sh "yarn run gatsby build"
+          sh "yarn run build"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -70,12 +70,10 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "npm run collect-content && gatsby build",
+    "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
-    "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "collect-content": "node ./scripts/collect-content.js"
   },
   "repository": {


### PR DESCRIPTION
This pr improves the build performance, by caching the `public` and `.cache` folder between builds.
The folders are archived and stored in a google bucket after successful build of the master branch.
The cache is downloaded and extracted before each build.
This reduces the amount of work which must be done to build the page.