### PR TITLE
Fix order of versions on docs page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,6 +11,7 @@ const { createFilePath } = require(`gatsby-source-filesystem`);
 
 const compareVersions = require("semver/functions/compare");
 const minVersion = require("semver/ranges/min-version");
+const { default: versionRangeComparator } = require("./src/lib/versionRangeComparator");
 
 // resolve src for mdx
 // https://github.com/ChristopherBiscardi/gatsby-mdx/issues/176#issuecomment-429569578
@@ -426,14 +427,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     const lastRelease = result.data.releases.nodes.map(node => node.tag)
       // remove rc releases
       .filter(tag => !tag.includes("-"))
-      .map(tag => {
-        // fix 1.x non semver tags
-        if (tag.split(".").length === 2) {
-          return `${tag}.0`;
-        }
-        return tag;
-      })
-      .sort(compareVersions)
+      .sort(versionRangeComparator)
       .reverse()[0];
 
     createRedirect({

--- a/src/components/NavigationSettings.tsx
+++ b/src/components/NavigationSettings.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { navigate } from "gatsby";
 import Setting from "./Setting";
 import LanguageSetting from "./LanguageSetting";
+import versionRangeComparator from "../lib/versionRangeComparator";
 
 export const PATH_PART_INDEX_DOCS_VERSION = 2;
 export const PATH_PART_INDEX_DOCS_LANGUAGE = 3;
@@ -58,7 +59,7 @@ const NavigationSettings: FC<Props> = ({ path, versionPathIndex, languagePathInd
         value={findVersion(path, versionPathIndex)}
         options={versions.group
           .map(g => g.fieldValue)
-          .sort()
+          .sort(versionRangeComparator)
           .reverse()}
         onChange={version => changeVersion(path, version, versionPathIndex)}
       />

--- a/src/lib/versionRangeComparator.js
+++ b/src/lib/versionRangeComparator.js
@@ -1,0 +1,20 @@
+// we use javascript, require and module.exports instead of import and export,
+// because this file is used from node (gatsby-node) and browser.
+
+const minVersion = require("semver/ranges/min-version");
+const compare = require("semver/functions/compare");
+
+const createSemVer = version => {
+  let semVer = version;
+  // fix 1.x non semver versions
+  if (semVer.split(".").length === 2) {
+    semVer += ".0";
+  }
+  return minVersion(semVer);
+};
+
+const versionRangeComparator = (a, b) => {
+  return compare(createSemVer(a), createSemVer(b));
+};
+
+module.exports = versionRangeComparator;


### PR DESCRIPTION
## Proposed changes

Use semver comparator to sort versions on docs page instead of alphabetical ordering.

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Code does not conflict with target branch

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
