### PR TITLE
Fix caching for branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,14 @@ pipeline {
 
   stages {
 
+    stage('Compute Version') {
+      steps {
+        script {
+          version = computeVersion()
+        }
+      }
+    }
+
     stage('Apply Cache') {
       steps {
         sh 'rm -rf public .cache website.tar.gz || true'
@@ -113,11 +121,13 @@ pipeline {
   }
 }
 
+String version
+
 String getSiteUrl() {
   return env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
 }
 
-String getVersion() {
+String computeVersion() {
   def commitHashShort = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
   return "${new Date().format('yyyyMMddHHmm')}-${commitHashShort}".trim()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,112 +1,113 @@
 #!groovy
-node('docker') {
+pipeline {
 
-  def version = 'UNKNOWN'
-
-  properties([
-    // Keep only the last 10 build to preserve space
-    buildDiscarder(logRotator(numToKeepStr: '10')),
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
     disableConcurrentBuilds()
-  ])
+  }
 
-  timeout(activity: true, time: 30, unit: 'MINUTES') {
+  agent {
+    node {
+      label 'docker'
+    }
+  }
 
-    catchError {
+  stages {
 
-      stage('Checkout') {
-        checkout scm
-
-        // TODO staging and prod use the same image and version scheme?
-        def commitHashShort = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
-        version = "${new Date().format('yyyyMMddHHmm')}-${commitHashShort}".trim()
-      }
-
-      stage('Apply Cache') {
+    stage('Apply Cache') {
+      steps {
         sh 'rm -rf public .cache website.tar.gz || true'
         googleStorageDownload bucketUri: 'gs://scm-manager/cache/website.tar.gz', credentialsId: 'ces-demo-instances', localDirectory: '.'
         sh 'tar xfz cache/website.tar.gz'
         sh 'rm -rf cache'
       }
-
-      stage('Dependencies') {
-        withNode {
-          sh "yarn install"
-        }
-      }
-
-      stage('Collect Content') {
-        withNode {
-          withCredentials([usernamePassword(credentialsId: 'cesmarvin-github', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_ACCOUNT')]) {
-            sh "yarn run collect-content"
-          }
-        }
-      }
-
-      stage('Build') {
-        def siteUrl = env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
-        withNode {
-          withEnv(["SITE_URL=${siteUrl}"]) {
-            sh "yarn run build"
-          }
-        }
-      }
-
-      stage('Image') {
-        def image = docker.build "scmmanager/website:${version}"
-        docker.withRegistry('', 'hub.docker.com-cesmarvin') {
-          image.push()
-        }
-      }
-
-      if (env.BRANCH_NAME == 'staging') {
-
-        stage('Staging Deployment') {
-          withHelm {
-            sh "helm upgrade --install --values=deployment/staging.yml --set image.tag=${version} staging-website deployment/website"
-          }
-        }
-
-      } else if (env.BRANCH_NAME == 'master') {
-
-        stage('Deployment') {
-          withHelm {
-            sh "helm upgrade --install --set image.tag=${version} website deployment/website"
-          }
-        }
-
-        stage('Trigger API Build') {
-          build job: 'scm-manager-github/plugin-center-api/master', wait: false
-        }
-
-        stage('Update Cache') {
-          sh "tar cfz website.tar.gz public .cache"
-          googleStorageUpload bucket: 'gs://scm-manager/cache', credentialsId: 'ces-operations-internal', pattern: 'website.tar.gz'
-        }
-
-      }
-
     }
-    if (currentBuild.currentResult == 'FAILURE') {
-      mail to: "scm-team@cloudogu.com",
-        subject: "${JOB_NAME} - Build #${BUILD_NUMBER} - ${currentBuild.currentResult}!",
-        body: "Check console output at ${BUILD_URL} to view the results."
+
+    stage('Build') {
+      agent {
+        docker {
+          image 'scmmanager/node-build:14.16.1'
+          label 'docker'
+          args  '-v ${PWD}:/usr/src/app -e HOME=/usr/src/app -w /usr/src/app'
+          reuseNode true
+        }
+      }
+      steps {
+        sh "yarn install"
+        withCredentials([usernamePassword(credentialsId: 'cesmarvin-github', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_ACCOUNT')]) {
+          sh "yarn run collect-content"
+        }
+        withEnv(["SITE_URL=${siteUrl}"]) {
+          sh "yarn run build"
+        }
+      }
+    }
+
+    stage('Image') {
+      steps {
+        script {
+          def image = docker.build "scmmanager/website:${version}"
+          docker.withRegistry('', 'hub.docker.com-cesmarvin') {
+            image.push()
+          }
+        }
+      }
+    }
+
+    stage('Staging Deployment') {
+      when {
+        branch 'staging'
+      }
+      agent {
+        docker {
+          image 'lachlanevenson/k8s-helm:v3.2.1'
+          label 'docker'
+          reuseNode true
+        }
+      }
+      steps {
+        sh "helm upgrade --install --values=deployment/staging.yml --set image.tag=${version} staging-website deployment/website"
+      }
+    }
+
+    stage('Deployment') {
+      when {
+        branch 'master'
+      }
+      agent {
+        docker {
+          image 'lachlanevenson/k8s-helm:v3.2.1'
+          label 'docker'
+          reuseNode true
+        }
+      }
+      steps {
+        sh "helm upgrade --install --set image.tag=${version} website deployment/website"
+      }
+    }
+
+    stage('Trigger API Build') {
+      when {
+        branch 'master'
+      }
+      steps {
+        build job: 'scm-manager-github/plugin-center-api/master', wait: false
+      }
+    }
+
+    stage('Update Cache') {
+      when {
+        branch 'master'
+      }
+      steps {
+        sh "tar cfz website.tar.gz public .cache"
+        googleStorageUpload bucket: 'gs://scm-manager/cache', credentialsId: 'ces-operations-internal', pattern: 'website.tar.gz'
+      }
     }
 
   }
 }
 
-void withNode(Closure closure) {
-  docker.image('scmmanager/node-build:14.16.1').inside {
-    withEnv(["HOME=${env.WORKSPACE}"]) {
-      closure.call()
-    }
-  }
-}
-
-void withHelm(Closure closure) {
-  docker.image('lachlanevenson/k8s-helm:v3.2.1').inside('--entrypoint=""') {
-    withCredentials([file(credentialsId: 'helm-client-scm-manager', variable: 'KUBECONFIG')]) {
-      closure.call()
-    }
-  }
+String getSiteUrl() {
+  return env.BRANCH_NAME == 'staging' ? 'https://staging-website.scm-manager.org' : 'https://scm-manager.org'
 }


### PR DESCRIPTION
## Proposed changes

The gatsby cache works at the moment only for the `master` branch. This is because gatsby writes the absolute path in its redux cache files and jenkins uses the branch name as part of the workspace path. With this change we execute the build always in the same directory of a docker container to get the same paths in the cache across all branches.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Code does not conflict with target branch

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
