### PR TITLE
implement canonical links correctly

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -393,7 +393,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
           .map(slugVersion => slugVersion.version)
           .sort(versionRangeComparator)[0];
 
-        console.log("create docs page", pagePath, pageVersion, latestDocsVersion);
         createPage(createDocPage(node, null, latestDocsVersion));
         if (latestDocsVersion === pageVersion) {
           createPage(createLatestDocPage(node));
@@ -407,7 +406,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
           .map(slugVersion => slugVersion.version)
           .sort(versionRangeComparator)[0];
         const pluginVersion = nodeSlugParts[4];
-        console.log("create plugin page", pluginName, pagePath, pluginVersion, latestPluginVersion);
         createPage(createPluginDocPage(node, null, latestPluginVersion));
         if (latestPluginVersion === pluginVersion) {
           createPage(createLatestPluginDocPage(node));

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -352,17 +352,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
           }
         }
       }
-      
-      pluginVersions: allPluginYaml {
-        group(field: name) {
-          fieldValue
-          nodes {
-            documentation {
-              version
-            }
-          }
-        }
-      }
 
       releases: allReleasesYaml(
         filter: { plugin: { eq: null } }
@@ -381,27 +370,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
 
     const defaultLanguage =
       result.data.languages.childrenLanguagesYaml[0].value;
-
-    // TODO: Remove this (And also the graphql query, if its not used elsewhere)
-    // const latestVersion = result.data.versions.group
-    //   .map(g => g.fieldValue)
-    //   .sort(versionRangeComparator)[0];
-
-    // TODO: Remove this (And also the graphql query, if its not used elsewhere)
-    // const latestPluginVersions = result.data.pluginVersions.group
-    //   .map((plugin) => {
-    //     const versions = { ...plugin.nodes }[0].documentation;
-    //     let latestVersion = null;
-    //     if (versions.length > 0) {
-    //       latestVersion = versions
-    //         .map(g => g.version)
-    //         .sort(versionRangeComparator)[0];
-    //     }
-    //     return {
-    //       name: plugin.fieldValue,
-    //       latestVersion,
-    //     };
-    //   });
 
     const slugVersions = result.data.allVersions.nodes.map(n => n.fields);
     const docsVersions = result.data.versions.nodes.map(n => n.fields);
@@ -425,7 +393,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
           .map(slugVersion => slugVersion.version)
           .sort(versionRangeComparator)[0];
 
-        console.log(pagePath, pageVersion, latestDocsVersion);
+        console.log("create docs page", pagePath, pageVersion, latestDocsVersion);
         createPage(createDocPage(node, null, latestDocsVersion));
         if (latestDocsVersion === pageVersion) {
           createPage(createLatestDocPage(node));
@@ -438,8 +406,9 @@ exports.createPages = ({ graphql, actions, reporter }) => {
         const latestPluginVersion = pluginSlugVersions
           .map(slugVersion => slugVersion.version)
           .sort(versionRangeComparator)[0];
-        createPage(createPluginDocPage(node, null, latestPluginVersion));
         const pluginVersion = nodeSlugParts[4];
+        console.log("create plugin page", pluginName, pagePath, pluginVersion, latestPluginVersion);
+        createPage(createPluginDocPage(node, null, latestPluginVersion));
         if (latestPluginVersion === pluginVersion) {
           createPage(createLatestPluginDocPage(node));
         }


### PR DESCRIPTION
## Proposed changes

Currently, canonical tags are not created to the latest version of a document for a given plugin/the core but to the latest overall version for a plugin/the core (e.g. if a page /downloads was present in version 1.0 of a plugin but not in the next version 1.1, then the canonical link would incorrectly point to the non-existent 1.1 version). Additionally, the canonical link would point to `latest` instead of the actual version identifier and would also point to the documentation root and not to the actual page path. The latest version of a plugin/the core would not have any canonical link.  This PR fixes all of these issues.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
