### PR TITLE
Create separate download page instead of redirect

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -535,11 +535,13 @@ exports.createPages = ({ graphql, actions, reporter }) => {
       .filter(tag => !tag.includes("-"))
       .sort(versionRangeComparator)[0];
 
-    createRedirect({
-      fromPath: `/download/`,
-      toPath: `/download/${lastRelease}/`,
-      isPermanent: false,
-      redirectInBrowser: true,
+    createPage({
+      path: `/download`,
+      component: path.resolve("./src/templates/download.tsx"),
+      context: {
+        tag: lastRelease,
+        latest: true
+      },
     });
 
     result.data.releases.nodes.map(node => node.tag).forEach(tag => {
@@ -547,7 +549,8 @@ exports.createPages = ({ graphql, actions, reporter }) => {
         path: `/download/${tag}`,
         component: path.resolve("./src/templates/download.tsx"),
         context: {
-          tag: tag,
+          tag,
+          latest: tag === lastRelease
         },
       });
     });

--- a/src/layout/NavbarMenu.tsx
+++ b/src/layout/NavbarMenu.tsx
@@ -25,7 +25,7 @@ const NavbarMenu = ({ active, toggleActive }: Props) => {
         <NavbarItem to="/" value="Home" />
         <NavbarItem to="/blog/" value="Blog" partiallyActive={true} />
         <NavbarItem
-          to={`/download/${release.tag}/`}
+          to={`/download`}
           activeOn="/download"
           value="Download"
           partiallyActive={true}

--- a/src/layout/NavbarMenu.tsx
+++ b/src/layout/NavbarMenu.tsx
@@ -25,7 +25,7 @@ const NavbarMenu = ({ active, toggleActive }: Props) => {
         <NavbarItem to="/" value="Home" />
         <NavbarItem to="/blog/" value="Blog" partiallyActive={true} />
         <NavbarItem
-          to={`/download`}
+          to={`/download/`}
           activeOn="/download"
           value="Download"
           partiallyActive={true}

--- a/src/templates/download.tsx
+++ b/src/templates/download.tsx
@@ -35,7 +35,7 @@ const DownloadPage: FC<PageProps<any, Context>> = ({ data, pageContext }) => {
 const NotLatestWarning = () => (
   <div className="notification is-warning">
     <p>This page does not refer to the most recent version of SCM-Manager.</p>
-    <Link to="/download">Go to the download of the latest Version</Link>
+    <Link to="/download/">Go to the download of the latest Version</Link>
   </div>
 );
 

--- a/src/templates/download.tsx
+++ b/src/templates/download.tsx
@@ -1,20 +1,28 @@
-import React from "react";
+import React, { FC } from "react";
 import SEO from "../components/SEO";
 import Title from "../components/Title";
 import Subtitle from "../components/Subtitle";
 import PageContainer from "../layout/PageContainer";
-import { graphql } from "gatsby";
+import { graphql, Link, PageProps } from "gatsby";
 import Download from "../components/Download";
 import ReleaseFeedNote from "../components/ReleaseFeedNote";
 
-const DownloadPage = ({ data }) => {
+type Context = {
+  tag: string;
+  latest: boolean;
+};
+
+const DownloadPage: FC<PageProps<any, Context>> = ({ data, pageContext }) => {
   return (
     <PageContainer>
-      <SEO title="Download" />
+      <SEO title={`Download ${pageContext.tag}`} />
       <Title>Download</Title>
       <Subtitle>
-        Download the latest and greatest version of SCM-Manager
+        {pageContext.latest
+          ? "Download the latest and greatest version of SCM-Manager"
+          : `Changelog and downloads for version ${pageContext.tag}`}
       </Subtitle>
+      {pageContext.latest ? null : <NotLatestWarning />}
       <ReleaseFeedNote />
       <Download
         release={data.releases.nodes[0]}
@@ -23,6 +31,13 @@ const DownloadPage = ({ data }) => {
     </PageContainer>
   );
 };
+
+const NotLatestWarning = () => (
+  <div className="notification is-warning">
+    <p>This page does not refer to the most recent version of SCM-Manager.</p>
+    <Link to="/download">Go to the download of the latest Version</Link>
+  </div>
+);
 
 export const query = graphql`
   query($tag: String!) {


### PR DESCRIPTION
Create a real /download page instead of a redirect to /download/latestversion.
Also we added a warning if the download page is not the latest.