### PR TITLE
Sort plugins independent of the case of the display name

### DIFF
--- a/src/templates/category.tsx
+++ b/src/templates/category.tsx
@@ -28,6 +28,9 @@ const Category = ({ data }) => {
     return data.cloudoguReleases.nodes.filter(r => r.plugin === node.name)[0]?.installLink;
   }
 
+  const sortedPlugins = [...plugins.nodes];
+  sortedPlugins.sort((firstEl, secondEl) => firstEl.displayName.toLowerCase() < secondEl.displayName.toLowerCase() ? -1 : 1);
+
   return (
     <Page>
       <SEO title={"Category " + category.displayName} />
@@ -38,7 +41,7 @@ const Category = ({ data }) => {
         </Title>
         <Subtitle>{category.description}</Subtitle>
         <PluginList className="content">
-          {plugins.nodes.map((node) => {
+          {sortedPlugins.map((node) => {
             const cloudoguLink = getCloudoguLink(node);
             return (
               <Plugin key={node.name} plugin={{ ...node, cloudoguLink }} />


### PR DESCRIPTION
## Proposed changes

This sorts the plugins by display name, but independently of their case. Doing so, the "htpasswd" plugin will be listed between the "History" and the "Issue Tracker" plugins, and not at he end of the list

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
